### PR TITLE
Add environment template and Docker support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+AZURE_CLIENT_ID=
+AZURE_TENANT_ID=
+AZURE_CLIENT_SECRET=
+MAILBOX_USER_ID=
+OPENROUTER_API_KEY=
+# optional: change only if using a custom OpenRouter instance
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "agentmail:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# outlook
+# Outlook AI Agent
+
+This project implements a simple email agent that interacts with Microsoft Graph and processes messages with OpenAI via the OpenRouter gateway.
+
+## Requirements
+
+- Python 3.11
+- Dependencies listed in `requirements.txt`
+
+## Quick start
+
+Install dependencies and run tests (a Python 3.11 environment is assumed):
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+Run the application:
+
+```bash
+uvicorn agentmail:app --reload --host 0.0.0.0 --port 8000
+```
+
+The application loads configuration from a `.env` file. Copy `.env.example` to
+`.env` and fill in your credentials. The required variables are:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_SECRET`
+- `MAILBOX_USER_ID`
+- `OPENROUTER_API_KEY`
+- `OPENROUTER_BASE_URL` *(optional, defaults to `https://openrouter.ai/api/v1`)*
+These values are used to authenticate to Microsoft Graph and the OpenRouter API.
+
+### Using a proxy
+
+If you run the agent behind an HTTP proxy, set the `HTTP_PROXY` and
+`HTTPS_PROXY` environment variables before starting the application so that the
+underlying libraries can route traffic correctly.
+
+### Docker deployment
+
+The repository includes a simple `Dockerfile` to run the service in a container.
+Build the image and run it:
+
+```bash
+docker build -t agentmail .
+docker run --env-file .env -p 8000:8000 agentmail
+```
+
+When run in Docker the container can join an existing network such as
+`nginx-proxy` to be served behind a reverse proxy.

--- a/agentmail.py
+++ b/agentmail.py
@@ -1,0 +1,70 @@
+import logging
+import os
+from typing import Dict
+
+import msal
+import openai
+import requests
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+
+load_dotenv()
+
+app = FastAPI()
+
+TENANT_ID = os.getenv("AZURE_TENANT_ID")
+CLIENT_ID = os.getenv("AZURE_CLIENT_ID")
+CLIENT_SECRET = os.getenv("AZURE_CLIENT_SECRET")
+MAILBOX_USER_ID = os.getenv("MAILBOX_USER_ID")
+
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+if OPENROUTER_API_KEY:
+    openai.api_key = OPENROUTER_API_KEY
+    openai.api_base = OPENROUTER_BASE_URL
+
+
+def get_access_token() -> str:
+    """Acquire a token from Microsoft identity platform."""
+    client = msal.ConfidentialClientApplication(
+        CLIENT_ID,
+        authority=f"https://login.microsoftonline.com/{TENANT_ID}",
+        client_credential=CLIENT_SECRET,
+    )
+    result = client.acquire_token_for_client(scopes=["https://graph.microsoft.com/.default"])
+    if "access_token" not in result:
+        raise RuntimeError(f"Token acquisition failed: {result.get('error_description')}")
+    return result["access_token"]
+
+
+def analyze_message(content: str) -> str:
+    """Analyze email content using OpenAI."""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": content}],
+    )
+    return response.choices[0].message["content"]
+
+
+@app.post("/graph/notifications")
+async def graph_notifications(request: Request) -> Dict[str, str]:
+    payload = await request.json()
+    if "value" not in payload:
+        raise HTTPException(status_code=400, detail="Invalid notification payload")
+
+    for note in payload["value"]:
+        message_id = note.get("resourceData", {}).get("id")
+        if not message_id:
+            continue
+        token = get_access_token()
+        msg = requests.get(
+            f"https://graph.microsoft.com/v1.0/users/{MAILBOX_USER_ID}/messages/{message_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        ).json()
+        content = msg.get("body", {}).get("content", "")
+        summary = analyze_message(content)
+        logging.info("Message %s summary: %s", message_id, summary)
+
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+msal
+requests
+openai
+python-dotenv
+pytest

--- a/tests/test_agentmail.py
+++ b/tests/test_agentmail.py
@@ -1,0 +1,20 @@
+import types
+
+import agentmail
+
+class FakeChatCompletion:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, model, messages):
+        self.calls.append((model, messages))
+        class Resp:
+            choices = [types.SimpleNamespace(message={"content": "Summary"})]
+        return Resp()
+
+def test_analyze_message(monkeypatch):
+    fake = FakeChatCompletion()
+    monkeypatch.setattr(agentmail.openai, "ChatCompletion", fake)
+    result = agentmail.analyze_message("Hello")
+    assert result == "Summary"
+    assert fake.calls


### PR DESCRIPTION
## Summary
- document using OpenRouter via .env configuration
- provide `.env.example`, `.gitignore`, and Dockerfile
- use `python-dotenv` to load secrets in `agentmail.py`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'msal')*


------
https://chatgpt.com/codex/tasks/task_e_685bf3892c2883269618b1228a30d170